### PR TITLE
Added version property to doc nodes

### DIFF
--- a/rust/src/adf_serialize.rs
+++ b/rust/src/adf_serialize.rs
@@ -6,6 +6,7 @@ pub fn to_value(node: &AdfNode) -> Value {
 
     match &node.kind {
         NodeKind::Doc => {
+            obj.insert("version".to_string(), json!(1));
             obj.insert("type".to_string(), json!("doc"));
             insert_children(&mut obj, &node.children);
         }

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -8,6 +8,7 @@ from pyadf import Document, MarkdownConfig, UnsupportedNodeTypeError
 class TestParagraph:
     def test_simple_paragraph(self):
         adf = {
+            "version": 1,
             "type": "doc",
             "content": [
                 {"type": "paragraph", "content": [{"type": "text", "text": "Hello, world!"}]},
@@ -17,6 +18,7 @@ class TestParagraph:
 
     def test_full_document_two_paragraphs(self):
         adf = {
+            "version": 1,
             "type": "doc",
             "content": [
                 {"type": "paragraph", "content": [{"type": "text", "text": "First paragraph"}]},
@@ -320,6 +322,7 @@ class TestBlockCard:
 
     def test_in_document(self):
         adf = {
+            "version": 1,
             "type": "doc",
             "content": [
                 {"type": "paragraph"},
@@ -339,6 +342,7 @@ class TestBlockCard:
 class TestKnownUnsupportedNodes:
     def test_extension_warns_by_default(self):
         adf = {
+            "version": 1,
             "type": "doc",
             "content": [
                 {"type": "paragraph", "content": [{"type": "text", "text": "Before"}]},

--- a/tests/test_markdown_adf_roundtrip.py
+++ b/tests/test_markdown_adf_roundtrip.py
@@ -11,6 +11,7 @@ class TestAdfRoundtripExact:
         [
             (
                 {
+                    "version": 1,
                     "type": "doc",
                     "content": [
                         {"type": "paragraph", "content": [{"type": "text", "text": "Hello"}]},
@@ -20,6 +21,7 @@ class TestAdfRoundtripExact:
             ),
             (
                 {
+                    "version": 1,
                     "type": "doc",
                     "content": [
                         {
@@ -33,6 +35,7 @@ class TestAdfRoundtripExact:
             ),
             (
                 {
+                    "version": 1,
                     "type": "doc",
                     "content": [
                         {
@@ -52,6 +55,7 @@ class TestAdfRoundtripExact:
             ),
             (
                 {
+                    "version": 1,
                     "type": "doc",
                     "content": [
                         {
@@ -68,6 +72,7 @@ class TestAdfRoundtripExact:
             ),
             (
                 {
+                    "version": 1,
                     "type": "doc",
                     "content": [
                         {
@@ -99,6 +104,7 @@ class TestAdfRoundtripExact:
             ),
             (
                 {
+                    "version": 1,
                     "type": "doc",
                     "content": [
                         {
@@ -130,6 +136,7 @@ class TestAdfRoundtripExact:
             ),
             (
                 {
+                    "version": 1,
                     "type": "doc",
                     "content": [
                         {
@@ -145,6 +152,7 @@ class TestAdfRoundtripExact:
             ),
             (
                 {
+                    "version": 1,
                     "type": "doc",
                     "content": [
                         {
@@ -158,6 +166,7 @@ class TestAdfRoundtripExact:
             ),
             (
                 {
+                    "version": 1,
                     "type": "doc",
                     "content": [
                         {
@@ -179,6 +188,7 @@ class TestAdfRoundtripExact:
 class TestTaskAdfAttrs:
     def test_task_attrs_are_preserved_in_to_adf(self):
         adf = {
+            "version": 1,
             "type": "doc",
             "content": [
                 {
@@ -204,6 +214,7 @@ class TestTaskAdfAttrs:
 
     def test_task_item_state_controls_markdown_checkbox(self):
         adf = {
+            "version": 1,
             "type": "doc",
             "content": [
                 {
@@ -230,6 +241,7 @@ class TestTaskAdfAttrs:
 class TestAdfRoundtripMarkdownStable:
     def test_panel_roundtrips_markdown_as_blockquote(self):
         adf = {
+            "version": 1,
             "type": "doc",
             "content": [
                 {

--- a/tests/test_markdown_compliance.py
+++ b/tests/test_markdown_compliance.py
@@ -8,6 +8,7 @@ class TestMarkdownCompliance:
         markdown = "> Info"
 
         assert Document.from_markdown(markdown).to_adf() == {
+            "version": 1,
             "type": "doc",
             "content": [
                 {
@@ -24,6 +25,7 @@ class TestMarkdownCompliance:
 
     def test_html_fallback_uses_div_at_root_context(self):
         adf = {
+            "version": 1,
             "type": "doc",
             "content": [{"type": "extension", "attrs": {"extensionKey": "toc"}}],
         }
@@ -34,6 +36,7 @@ class TestMarkdownCompliance:
 
     def test_html_fallback_uses_span_in_paragraph_context(self):
         adf = {
+            "version": 1,
             "type": "doc",
             "content": [
                 {
@@ -52,6 +55,7 @@ class TestMarkdownCompliance:
 
     def test_html_fallback_uses_span_in_table_cell_context(self):
         adf = {
+            "version": 1,
             "type": "doc",
             "content": [
                 {

--- a/tests/test_markdown_parse.py
+++ b/tests/test_markdown_parse.py
@@ -8,6 +8,7 @@ from pyadf import Document, MarkdownParseError, markdown_to_adf
 class TestToAdf:
     def test_existing_document_can_serialize_to_adf(self):
         adf = {
+            "version": 1,
             "type": "doc",
             "content": [
                 {"type": "paragraph", "content": [{"type": "text", "text": "Hello"}]},
@@ -20,6 +21,7 @@ class TestToAdf:
 class TestFromMarkdown:
     def test_simple_paragraph(self):
         assert Document.from_markdown("Hello").to_adf() == {
+            "version": 1,
             "type": "doc",
             "content": [
                 {"type": "paragraph", "content": [{"type": "text", "text": "Hello"}]},
@@ -28,6 +30,7 @@ class TestFromMarkdown:
 
     def test_heading(self):
         assert Document.from_markdown("# Title").to_adf() == {
+            "version": 1,
             "type": "doc",
             "content": [
                 {
@@ -40,6 +43,7 @@ class TestFromMarkdown:
 
     def test_strong_and_emphasis(self):
         assert Document.from_markdown("***Hi***").to_adf() == {
+            "version": 1,
             "type": "doc",
             "content": [
                 {
@@ -57,6 +61,7 @@ class TestFromMarkdown:
 
     def test_link(self):
         assert Document.from_markdown("[x](http://example.com)").to_adf() == {
+            "version": 1,
             "type": "doc",
             "content": [
                 {
@@ -74,6 +79,7 @@ class TestFromMarkdown:
 
     def test_bullet_list(self):
         assert Document.from_markdown("- A\n- B").to_adf() == {
+            "version": 1,
             "type": "doc",
             "content": [
                 {
@@ -104,6 +110,7 @@ class TestFromMarkdown:
 
     def test_ordered_list(self):
         assert Document.from_markdown("1. A\n2. B").to_adf() == {
+            "version": 1,
             "type": "doc",
             "content": [
                 {
@@ -134,6 +141,7 @@ class TestFromMarkdown:
 
     def test_hard_break(self):
         assert Document.from_markdown("A  \nB").to_adf() == {
+            "version": 1,
             "type": "doc",
             "content": [
                 {
@@ -149,6 +157,7 @@ class TestFromMarkdown:
 
     def test_blockquote_two_paragraphs(self):
         assert Document.from_markdown("> A\n>\n> B").to_adf() == {
+            "version": 1,
             "type": "doc",
             "content": [
                 {
@@ -169,6 +178,7 @@ class TestFromMarkdown:
 
     def test_table(self):
         assert Document.from_markdown("| A | B |\n| --- | --- |\n| C | D |").to_adf() == {
+            "version": 1,
             "type": "doc",
             "content": [
                 {
@@ -219,6 +229,7 @@ class TestFromMarkdown:
         )
 
         assert Document.from_markdown(markdown).to_adf() == {
+            "version": 1,
             "type": "doc",
             "content": [
                 {
@@ -238,6 +249,7 @@ class TestFromMarkdown:
         )
 
         assert Document.from_markdown(markdown).to_adf() == {
+            "version": 1,
             "type": "doc",
             "content": [
                 {

--- a/tests/test_markdown_parse_direct.py
+++ b/tests/test_markdown_parse_direct.py
@@ -6,6 +6,7 @@ from pyadf import Document
 class TestDirectParsePass:
     def test_underscore_emphasis_maps_to_em_mark(self):
         assert Document.from_markdown("_x_").to_adf() == {
+            "version": 1,
             "type": "doc",
             "content": [
                 {
@@ -17,6 +18,7 @@ class TestDirectParsePass:
 
     def test_underscore_strong_maps_to_strong_mark(self):
         assert Document.from_markdown("__x__").to_adf() == {
+            "version": 1,
             "type": "doc",
             "content": [
                 {
@@ -28,6 +30,7 @@ class TestDirectParsePass:
 
     def test_heading_with_strong_mark(self):
         assert Document.from_markdown("## **Title**").to_adf() == {
+            "version": 1,
             "type": "doc",
             "content": [
                 {
@@ -40,6 +43,7 @@ class TestDirectParsePass:
 
     def test_combined_strong_em_link_order(self):
         assert Document.from_markdown("***[x](http://e.com)***").to_adf() == {
+            "version": 1,
             "type": "doc",
             "content": [
                 {
@@ -61,6 +65,7 @@ class TestDirectParsePass:
 
     def test_autolink_maps_to_link_mark(self):
         assert Document.from_markdown("<http://e.com>").to_adf() == {
+            "version": 1,
             "type": "doc",
             "content": [
                 {
@@ -78,6 +83,7 @@ class TestDirectParsePass:
 
     def test_inline_code_maps_to_code_mark(self):
         assert Document.from_markdown("`code`").to_adf() == {
+            "version": 1,
             "type": "doc",
             "content": [
                 {
@@ -95,6 +101,7 @@ class TestDirectParsePass:
 
     def test_linked_inline_code_uses_code_and_link_marks(self):
         assert Document.from_markdown("[`code`](http://e.com)").to_adf() == {
+            "version": 1,
             "type": "doc",
             "content": [
                 {
@@ -115,6 +122,7 @@ class TestDirectParsePass:
 
     def test_strikethrough_maps_to_strike_mark(self):
         assert Document.from_markdown("~~x~~").to_adf() == {
+            "version": 1,
             "type": "doc",
             "content": [
                 {
@@ -132,6 +140,7 @@ class TestDirectParsePass:
 
     def test_unchecked_task_list_maps_to_todo_task_item(self):
         assert Document.from_markdown("- [ ] task").to_adf() == {
+            "version": 1,
             "type": "doc",
             "content": [
                 {
@@ -154,6 +163,7 @@ class TestDirectParsePass:
 
     def test_checked_task_list_maps_to_done_task_item(self):
         assert Document.from_markdown("- [x] task").to_adf() == {
+            "version": 1,
             "type": "doc",
             "content": [
                 {
@@ -176,6 +186,7 @@ class TestDirectParsePass:
 
     def test_code_block_with_blank_lines(self):
         assert Document.from_markdown("```\na\n\nb\n```").to_adf() == {
+            "version": 1,
             "type": "doc",
             "content": [
                 {
@@ -187,6 +198,7 @@ class TestDirectParsePass:
 
     def test_code_block_uses_first_info_token_as_language(self):
         assert Document.from_markdown("```python linenos\nprint(1)\n```").to_adf() == {
+            "version": 1,
             "type": "doc",
             "content": [
                 {
@@ -199,6 +211,7 @@ class TestDirectParsePass:
 
     def test_blockquote_with_list(self):
         assert Document.from_markdown("> - A\n> - B").to_adf() == {
+            "version": 1,
             "type": "doc",
             "content": [
                 {
@@ -234,6 +247,7 @@ class TestDirectParsePass:
 
     def test_blockquote_with_code_block(self):
         assert Document.from_markdown("> ```\n> x\n> ```").to_adf() == {
+            "version": 1,
             "type": "doc",
             "content": [
                 {
@@ -253,6 +267,7 @@ class TestDirectParsePass:
             '<div adf="extension" params=\'{"text":"Tom &amp; Jerry","value":"it&#39;s"}\'></div>'
         )
         assert Document.from_markdown(markdown).to_adf() == {
+            "version": 1,
             "type": "doc",
             "content": [
                 {
@@ -266,6 +281,7 @@ class TestDirectParsePass:
 class TestDirectParseKnownGaps:
     def test_nested_bullet_list(self):
         assert Document.from_markdown("- A\n  - B").to_adf() == {
+            "version": 1,
             "type": "doc",
             "content": [
                 {
@@ -301,6 +317,7 @@ class TestDirectParseKnownGaps:
 
     def test_multi_paragraph_list_item(self):
         assert Document.from_markdown("- A\n\n  B").to_adf() == {
+            "version": 1,
             "type": "doc",
             "content": [
                 {
@@ -328,6 +345,7 @@ class TestDirectParseKnownGaps:
         assert Document.from_markdown(
             "| **A** | [B](http://e.com) |\n| --- | --- |\n| C | D |"
         ).to_adf() == {
+            "version": 1,
             "type": "doc",
             "content": [
                 {


### PR DESCRIPTION
Added the "version" property to doc nodes, since the current version of ADF requires a "version" property to be in the root, otherwise it will not be recognized by services that use ADF (e.g., Jira).

Source: https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/ 
