### PR TITLE
feat: add date node support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,10 +122,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -146,6 +192,8 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 name = "pyadf-core"
 version = "0.5.1"
 dependencies = [
+ "chrono",
+ "chrono-tz",
  "pulldown-cmark",
  "pyo3",
  "rayon",
@@ -291,6 +339,12 @@ dependencies = [
  "serde_core",
  "zmij",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ pyo3 = { version = "0.24", features = ["extension-module", "abi3-py311"] }
 serde_json = "1"
 rayon = "1.10"
 pulldown-cmark = "0.13"
+chrono = { version = "0.4", default-features = false, features = ["std", "alloc"] }
+chrono-tz = "0.10"
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A high-performance Python library for converting [Atlassian Document Format (ADF
   - Code blocks with syntax highlighting
   - Blockquotes and panels
   - Status badges, inline cards, block cards, emoji, mentions
+  - Dates with configurable timezone and format
 - **Streaming JSONL API** for ETL pipelines processing millions of documents
 
 ## Installation
@@ -195,6 +196,8 @@ doc.to_markdown(config)  # [Link text]
 |--------|--------|---------|-------------|
 | `bullet_marker` | `+`, `-`, `*` | `-` | Character used for bullet list items |
 | `show_links` | `True`, `False` | `True` | Show underlying links in markdown |
+| `date_timezone` | IANA timezone name | `UTC` | Timezone used to render `date` nodes (e.g. `America/New_York`) |
+| `date_format` | [strftime](https://docs.rs/chrono/latest/chrono/format/strftime/index.html) pattern | `%Y-%m-%dT%H:%M:%S%:z` | Format used to render `date` nodes |
 
 ## Supported Markdown Import Subset
 
@@ -252,6 +255,7 @@ These node types are recognized but not rendered. By default they are warned:
 | `hardBreak` | Line break | |
 | `mention` | `@DisplayName` | Jira user mentions |
 | `blockCard` | `[link]` or code block | Link previews |
+| `date` | `2020-02-19T22:49:19+00:00` | Configurable via `date_timezone` / `date_format` |
 
 ## Exception Types
 
@@ -307,6 +311,10 @@ ruff format --check src/ tests/ benchmarks/
 MIT License — see LICENSE file for details.
 
 ## Changelog
+
+### Unreleased
+
+- Add `date` node support, rendered via the new `MarkdownConfig.date_timezone` (IANA timezone, default `UTC`) and `date_format` (strftime, default ISO 8601 date-time) options
 
 ### 0.5.1
 

--- a/docs/adf-element-policy.md
+++ b/docs/adf-element-policy.md
@@ -56,7 +56,7 @@ Status meanings:
 | `status`[^node-status] | native | reject | Markdown-like output is ambiguous with plain formatted text. |
 | `emoji`[^node-emoji] | native | reject | Markdown import treats emoji text as plain text. |
 | `mention`[^node-mention] | native | reject | Markdown import treats mention text as plain text. |
-| `date`[^node-date] | defer | defer | Jira element not yet represented in pyadf's native node enum. |
+| `date`[^node-date] | native | reject | Renders the epoch-millisecond `timestamp` via `MarkdownConfig.date_timezone`/`date_format`; Markdown import treats the formatted date as plain text. |
 | `nestedExpand`[^node-nestedexpand] | defer | defer | Jira element not yet represented in pyadf's native node enum. |
 | `extensionFrame` | defer | defer | Listed in the structure index, but not yet represented in pyadf's native node enum. |
 | `expand`[^node-expand] | html-fallback | reject | Known unsupported node; fallback HTML only. |

--- a/rust/src/adf_node.rs
+++ b/rust/src/adf_node.rs
@@ -79,6 +79,10 @@ pub enum NodeKind {
     Mention {
         text: Option<String>,
     },
+    Date {
+        /// Unix epoch timestamp in milliseconds.
+        timestamp: i64,
+    },
     BlockCard {
         url: Option<String>,
         data: Option<String>,
@@ -121,6 +125,7 @@ const SUPPORTED_TYPES: &[&str] = &[
     "emoji",
     "mention",
     "blockCard",
+    "date",
 ];
 
 /// Convert to Vec<String> only when needed (error messages).
@@ -376,6 +381,10 @@ fn build_node_kind(
             let text = attr_opt_string(attrs, "text");
             Ok(NodeKind::Mention { text })
         }
+        "date" => {
+            let timestamp = parse_date_timestamp(attrs, current_path)?;
+            Ok(NodeKind::Date { timestamp })
+        }
         "blockCard" => {
             let url = attr_opt_string(attrs, "url");
             let data = attr_opt_string(attrs, "data");
@@ -410,6 +419,38 @@ fn parse_doc_version(
             expected_values: Some(vec!["1".to_string()]),
         }),
     }
+}
+
+/// Parse the `date` node's `timestamp` attr into Unix epoch milliseconds.
+///
+/// The ADF spec defines `timestamp` as a string holding the epoch milliseconds,
+/// so only a string is accepted. A missing value, a non-string value, or a
+/// string that does not parse as an integer is a hard input error.
+fn parse_date_timestamp(
+    attrs: &serde_json::Map<String, Value>,
+    node_path: &str,
+) -> Result<i64, AdfError> {
+    let value = attrs
+        .get("timestamp")
+        .ok_or_else(|| AdfError::MissingField {
+            field_name: "timestamp".to_string(),
+            node_type: Some("date".to_string()),
+            node_path: Some(node_path_or_root(node_path)),
+            expected_values: None,
+        })?;
+
+    let parsed = match value {
+        Value::String(s) => s.parse::<i64>().ok(),
+        _ => None,
+    };
+
+    parsed.ok_or_else(|| AdfError::InvalidField {
+        field_name: "timestamp".to_string(),
+        invalid_value: format!("{value}"),
+        node_type: Some("date".to_string()),
+        node_path: Some(node_path_or_root(node_path)),
+        expected_values: None,
+    })
 }
 
 fn attr_string(attrs: &serde_json::Map<String, Value>, key: &str) -> String {
@@ -634,6 +675,44 @@ mod tests {
         match &node.kind {
             NodeKind::Heading { level } => assert_eq!(*level, 2),
             other => panic!("Expected Heading, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_date_string_timestamp() {
+        let json = r#"{"type":"date","attrs":{"timestamp":"1582152559000"}}"#;
+        let node = parse_adf(json).unwrap().node;
+        match node.kind {
+            NodeKind::Date { timestamp } => assert_eq!(timestamp, 1582152559000),
+            other => panic!("Expected Date, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_date_rejects_integer_timestamp() {
+        // The ADF spec requires a string; a JSON integer is malformed input.
+        let result = parse_adf(r#"{"type":"date","attrs":{"timestamp":1582152559000}}"#);
+        match result.unwrap_err() {
+            AdfError::InvalidField { field_name, .. } => assert_eq!(field_name, "timestamp"),
+            other => panic!("Expected InvalidField, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_date_missing_timestamp() {
+        let result = parse_adf(r#"{"type":"date","attrs":{}}"#);
+        match result.unwrap_err() {
+            AdfError::MissingField { field_name, .. } => assert_eq!(field_name, "timestamp"),
+            other => panic!("Expected MissingField, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_date_non_numeric_timestamp() {
+        let result = parse_adf(r#"{"type":"date","attrs":{"timestamp":"not-a-number"}}"#);
+        match result.unwrap_err() {
+            AdfError::InvalidField { field_name, .. } => assert_eq!(field_name, "timestamp"),
+            other => panic!("Expected InvalidField, got: {other:?}"),
         }
     }
 

--- a/rust/src/adf_serialize.rs
+++ b/rust/src/adf_serialize.rs
@@ -87,6 +87,13 @@ pub fn to_value(node: &AdfNode) -> Value {
                 obj.insert("attrs".to_string(), json!({ "text": text }));
             }
         }
+        NodeKind::Date { timestamp } => {
+            obj.insert("type".to_string(), json!("date"));
+            obj.insert(
+                "attrs".to_string(),
+                json!({ "timestamp": timestamp.to_string() }),
+            );
+        }
         NodeKind::BlockCard { url, data } => {
             obj.insert("type".to_string(), json!("blockCard"));
             insert_attrs(&mut obj, card_attrs(url, data));

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -1,3 +1,5 @@
+use chrono::format::{Item, StrftimeItems};
+use chrono_tz::Tz;
 use pyo3::prelude::*;
 
 use crate::errors::AdfError;
@@ -7,19 +9,27 @@ use crate::errors::AdfError;
 pub struct MarkdownConfig {
     pub bullet_marker: String,
     pub show_links: bool,
+    pub date_format: String,
+    pub date_timezone: String,
 }
 
 impl MarkdownConfig {
-    pub fn new(bullet_marker: &str, show_links: bool) -> Result<Self, AdfError> {
-        match bullet_marker {
-            "+" | "-" | "*" => Ok(Self {
-                bullet_marker: bullet_marker.to_string(),
-                show_links,
-            }),
-            _ => Err(AdfError::InvalidConfig {
-                message: format!("Invalid bullet_marker: {bullet_marker:?}"),
-            }),
-        }
+    pub fn new(
+        bullet_marker: &str,
+        show_links: bool,
+        date_timezone: &str,
+        date_format: &str,
+    ) -> Result<Self, AdfError> {
+        validate_bullet_marker(bullet_marker)
+            .map_err(|message| AdfError::InvalidConfig { message })?;
+        validate_timezone(date_timezone).map_err(|message| AdfError::InvalidConfig { message })?;
+        validate_date_format(date_format).map_err(|message| AdfError::InvalidConfig { message })?;
+        Ok(Self {
+            bullet_marker: bullet_marker.to_string(),
+            show_links,
+            date_format: date_format.to_string(),
+            date_timezone: date_timezone.to_string(),
+        })
     }
 }
 
@@ -28,8 +38,31 @@ impl Default for MarkdownConfig {
         Self {
             bullet_marker: "-".to_string(),
             show_links: true,
+            date_format: "%Y-%m-%dT%H:%M:%S%:z".to_string(),
+            date_timezone: "UTC".to_string(),
         }
     }
+}
+
+fn validate_bullet_marker(bullet_marker: &str) -> Result<(), String> {
+    match bullet_marker {
+        "+" | "-" | "*" => Ok(()),
+        _ => Err(format!("Invalid bullet_marker: {bullet_marker:?}")),
+    }
+}
+
+fn validate_timezone(timezone: &str) -> Result<(), String> {
+    timezone
+        .parse::<Tz>()
+        .map(|_| ())
+        .map_err(|_| format!("Invalid date_timezone: {timezone:?}"))
+}
+
+fn validate_date_format(format: &str) -> Result<(), String> {
+    if StrftimeItems::new(format).any(|item| matches!(item, Item::Error)) {
+        return Err(format!("Invalid date_format: {format:?}"));
+    }
+    Ok(())
 }
 
 /// Python-exposed markdown configuration.
@@ -41,22 +74,36 @@ pub struct PyMarkdownConfig {
     pub bullet_marker: String,
     #[pyo3(get)]
     pub show_links: bool,
+    #[pyo3(get)]
+    pub date_timezone: String,
+    #[pyo3(get)]
+    pub date_format: String,
 }
 
 #[pymethods]
 impl PyMarkdownConfig {
     #[new]
-    #[pyo3(signature = (bullet_marker="-", show_links=true))]
-    fn new(bullet_marker: &str, show_links: bool) -> PyResult<Self> {
-        match bullet_marker {
-            "+" | "-" | "*" => Ok(Self {
-                bullet_marker: bullet_marker.to_string(),
-                show_links,
-            }),
-            _ => Err(pyo3::exceptions::PyValueError::new_err(format!(
-                "Invalid bullet_marker: {bullet_marker:?}"
-            ))),
-        }
+    #[pyo3(signature = (
+        bullet_marker="-",
+        show_links=true,
+        date_timezone="UTC",
+        date_format="%Y-%m-%dT%H:%M:%S%:z",
+    ))]
+    fn new(
+        bullet_marker: &str,
+        show_links: bool,
+        date_timezone: &str,
+        date_format: &str,
+    ) -> PyResult<Self> {
+        validate_bullet_marker(bullet_marker).map_err(pyo3::exceptions::PyValueError::new_err)?;
+        validate_timezone(date_timezone).map_err(pyo3::exceptions::PyValueError::new_err)?;
+        validate_date_format(date_format).map_err(pyo3::exceptions::PyValueError::new_err)?;
+        Ok(Self {
+            bullet_marker: bullet_marker.to_string(),
+            show_links,
+            date_timezone: date_timezone.to_string(),
+            date_format: date_format.to_string(),
+        })
     }
 }
 
@@ -65,6 +112,8 @@ impl PyMarkdownConfig {
         MarkdownConfig {
             bullet_marker: self.bullet_marker.clone(),
             show_links: self.show_links,
+            date_format: self.date_format.clone(),
+            date_timezone: self.date_timezone.clone(),
         }
     }
 }

--- a/rust/src/markdown.rs
+++ b/rust/src/markdown.rs
@@ -110,6 +110,7 @@ fn render_node(
             render_mention(text.as_deref(), out);
             Ok(())
         }
+        NodeKind::Date { timestamp } => render_date(*timestamp, ctx, out),
         NodeKind::BlockCard { url, data } => {
             render_block_card(url.as_deref(), data.as_deref(), out);
             Ok(())
@@ -488,6 +489,33 @@ fn render_mention(text: Option<&str>, out: &mut String) {
     out.push_str(text.unwrap_or(""));
 }
 
+fn render_date(timestamp_ms: i64, ctx: &RenderContext, out: &mut String) -> Result<(), AdfError> {
+    use chrono::TimeZone;
+    use chrono_tz::Tz;
+
+    let dt_utc = match chrono::Utc.timestamp_millis_opt(timestamp_ms) {
+        chrono::offset::LocalResult::Single(dt) => dt,
+        _ => {
+            return Err(AdfError::InvalidField {
+                field_name: "timestamp".to_string(),
+                invalid_value: timestamp_ms.to_string(),
+                node_type: Some("date".to_string()),
+                node_path: None,
+                expected_values: None,
+            });
+        }
+    };
+
+    // Validated at config construction; fall back to UTC defensively.
+    let tz: Tz = ctx.config.date_timezone.parse().unwrap_or(Tz::UTC);
+    let formatted = dt_utc
+        .with_timezone(&tz)
+        .format(&ctx.config.date_format)
+        .to_string();
+    out.push_str(&formatted);
+    Ok(())
+}
+
 fn render_block_card(url: Option<&str>, data: Option<&str>, out: &mut String) {
     if let Some(url) = url {
         out.push_str(&format!("[{url}]"));
@@ -735,7 +763,7 @@ mod tests {
     #[test]
     fn link_text_hide_when_disabled() {
         let json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"click","marks":[{"type":"link","attrs":{"href":"http://example.com/"}}]}]}]}"#;
-        let config = MarkdownConfig::new("-", false).unwrap();
+        let config = MarkdownConfig::new("-", false, "UTC", "%Y-%m-%dT%H:%M:%S%:z").unwrap();
         assert_eq!(convert_with(json, &config), "[click]");
     }
 
@@ -769,7 +797,7 @@ mod tests {
     #[test]
     fn bullet_list_star() {
         let json = r#"{"type":"bulletList","content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"A"}]}]}]}"#;
-        let config = MarkdownConfig::new("*", false).unwrap();
+        let config = MarkdownConfig::new("*", false, "UTC", "%Y-%m-%dT%H:%M:%S%:z").unwrap();
         assert_eq!(convert_with(json, &config), "* A");
     }
 
@@ -837,6 +865,46 @@ mod tests {
     fn mention_without_text() {
         let json = r#"{"type":"mention","attrs":{"id":"123"}}"#;
         assert_eq!(convert(json), "");
+    }
+
+    #[test]
+    fn date_default_iso_utc() {
+        // 1582152559000 ms == 2020-02-19T22:49:19Z
+        let json = r#"{"type":"date","attrs":{"timestamp":"1582152559000"}}"#;
+        assert_eq!(convert(json), "2020-02-19T22:49:19+00:00");
+    }
+
+    #[test]
+    fn date_custom_format() {
+        let json = r#"{"type":"date","attrs":{"timestamp":"1582152559000"}}"#;
+        let config = MarkdownConfig::new("-", true, "UTC", "%Y-%m-%d").unwrap();
+        assert_eq!(convert_with(json, &config), "2020-02-19");
+    }
+
+    #[test]
+    fn date_named_timezone_shifts_day() {
+        // 2020-02-19T22:49:19Z is 2020-02-20 in Asia/Seoul (+09:00).
+        let json = r#"{"type":"date","attrs":{"timestamp":"1582152559000"}}"#;
+        let config = MarkdownConfig::new("-", true, "Asia/Seoul", "%Y-%m-%d").unwrap();
+        assert_eq!(convert_with(json, &config), "2020-02-20");
+    }
+
+    #[test]
+    fn date_inline_with_text() {
+        let json = r#"{"version":1,"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Due: "},{"type":"date","attrs":{"timestamp":"1582152559000"}}]}]}"#;
+        assert_eq!(convert(json), "Due: 2020-02-19T22:49:19+00:00");
+    }
+
+    #[test]
+    fn config_rejects_invalid_timezone() {
+        let result = MarkdownConfig::new("-", true, "Mars/Olympus", "%Y-%m-%d");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn config_rejects_invalid_date_format() {
+        let result = MarkdownConfig::new("-", true, "UTC", "%Q");
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/pyadf/__init__.py
+++ b/src/pyadf/__init__.py
@@ -92,7 +92,12 @@ def convert_jsonl(
 
     rust_config = None
     if config is not None:
-        rust_config = _core.MarkdownConfig(config.bullet_marker, config.show_links)
+        rust_config = _core.MarkdownConfig(
+            config.bullet_marker,
+            config.show_links,
+            config.date_timezone,
+            config.date_format,
+        )
 
     if isinstance(source, str):
         stream: BinaryIO = open(source, "rb")  # noqa: SIM115

--- a/src/pyadf/_core.pyi
+++ b/src/pyadf/_core.pyi
@@ -12,7 +12,15 @@ class MarkdownConfig:
 
     bullet_marker: str
     show_links: bool
-    def __init__(self, bullet_marker: str = "+", show_links: bool = False) -> None: ...
+    date_timezone: str
+    date_format: str
+    def __init__(
+        self,
+        bullet_marker: str = "-",
+        show_links: bool = True,
+        date_timezone: str = "UTC",
+        date_format: str = "%Y-%m-%dT%H:%M:%S%:z",
+    ) -> None: ...
 
 def parse_adf_str(json: str) -> ParsedAdf: ...
 def parse_adf_dict(adf_dict: Any) -> ParsedAdf: ...

--- a/src/pyadf/document.py
+++ b/src/pyadf/document.py
@@ -113,7 +113,12 @@ class Document:
 
         rust_config = None
         if config is not None:
-            rust_config = _core.MarkdownConfig(config.bullet_marker, config.show_links)
+            rust_config = _core.MarkdownConfig(
+                config.bullet_marker,
+                config.show_links,
+                config.date_timezone,
+                config.date_format,
+            )
 
         markdown, warnings_info = _core.render_markdown(
             self._parsed, rust_config, on_known_unsupported

--- a/src/pyadf/markdown.py
+++ b/src/pyadf/markdown.py
@@ -12,6 +12,8 @@ class MarkdownConfig:
 
     bullet_marker: BulletMarker = "-"
     show_links: bool = True
+    date_timezone: str = "UTC"
+    date_format: str = "%Y-%m-%dT%H:%M:%S%:z"
 
     def __post_init__(self) -> None:
         if self.bullet_marker not in ("+", "-", "*"):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,3 +40,24 @@ class TestShowLinks:
 
     def test_can_disable_link_targets(self):
         assert MarkdownConfig(show_links=False).show_links is False
+
+
+class TestDateConfig:
+    def _date_doc(self) -> dict:
+        # 1582152559000 ms == 2020-02-19T22:49:19Z
+        return {"type": "date", "attrs": {"timestamp": "1582152559000"}}
+
+    def test_defaults(self):
+        config = MarkdownConfig()
+        assert config.date_timezone == "UTC"
+        assert config.date_format == "%Y-%m-%dT%H:%M:%S%:z"
+
+    def test_invalid_timezone_raises(self):
+        config = MarkdownConfig(date_timezone="Mars/Olympus")
+        with pytest.raises(ValueError, match="Invalid date_timezone"):
+            Document(self._date_doc()).to_markdown(config)
+
+    def test_invalid_date_format_raises(self):
+        config = MarkdownConfig(date_format="%Q")
+        with pytest.raises(ValueError, match="Invalid date_format"):
+            Document(self._date_doc()).to_markdown(config)

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -2,7 +2,13 @@
 
 import pytest
 
-from pyadf import Document, MarkdownConfig, UnsupportedNodeTypeError
+from pyadf import (
+    Document,
+    InvalidFieldError,
+    MarkdownConfig,
+    MissingFieldError,
+    UnsupportedNodeTypeError,
+)
 
 
 class TestParagraph:
@@ -417,3 +423,58 @@ class TestKnownUnsupportedNodes:
             'params=\'{"extensionKey":"toc",'
             '"extensionType":"com.atlassian.confluence.macro.core"}\'></span> |'
         )
+
+
+class TestDate:
+    # 1582152559000 ms == 2020-02-19T22:49:19Z
+    def _date_doc(self, timestamp: str | int = "1582152559000") -> dict:
+        return {
+            "version": 1,
+            "type": "doc",
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {"type": "text", "text": "Due: "},
+                        {"type": "date", "attrs": {"timestamp": timestamp}},
+                    ],
+                }
+            ],
+        }
+
+    def test_default_iso_utc(self):
+        assert Document(self._date_doc()).to_markdown() == "Due: 2020-02-19T22:49:19+00:00"
+
+    def test_integer_timestamp_raises(self):
+        with pytest.raises(InvalidFieldError) as exc_info:
+            Document(self._date_doc(1582152559000))
+        assert "timestamp" in str(exc_info.value)
+
+    def test_custom_format_date_only(self):
+        config = MarkdownConfig(date_format="%Y-%m-%d")
+        assert Document(self._date_doc()).to_markdown(config) == "Due: 2020-02-19"
+
+    def test_named_timezone_shifts_day(self):
+        # 22:49Z is the next calendar day in Seoul (+09:00).
+        config = MarkdownConfig(date_timezone="Asia/Seoul", date_format="%Y-%m-%d")
+        assert Document(self._date_doc()).to_markdown(config) == "Due: 2020-02-20"
+
+    def test_named_timezone_is_dst_aware(self):
+        config = MarkdownConfig(date_timezone="America/New_York", date_format="%Y-%m-%d %H:%M %Z")
+        assert Document(self._date_doc()).to_markdown(config) == "Due: 2020-02-19 17:49 EST"
+
+    def test_missing_timestamp_raises(self):
+        adf = {"type": "date", "attrs": {}}
+        with pytest.raises(MissingFieldError) as exc_info:
+            Document(adf)
+        assert "timestamp" in str(exc_info.value)
+
+    def test_non_numeric_timestamp_raises(self):
+        adf = {"type": "date", "attrs": {"timestamp": "not-a-number"}}
+        with pytest.raises(InvalidFieldError) as exc_info:
+            Document(adf)
+        assert "timestamp" in str(exc_info.value)
+
+    def test_roundtrip_serializes_timestamp_as_string(self):
+        adf = {"type": "date", "attrs": {"timestamp": "1582152559000"}}
+        assert Document(adf).to_adf() == adf


### PR DESCRIPTION
Closes #17.

Adds support for the ADF [`date` node](https://developer.atlassian.com/cloud/jira/platform/apis/document/nodes/date/), which previously raised `UnsupportedNodeTypeError`.

## Approach

Rust-side rendering with a deterministic default, matching the rest of the conversion logic (per the discussion in #17). Adds `chrono` + `chrono-tz`; no `date_renderer` callback.

The `attrs.timestamp` is interpreted as **Unix epoch milliseconds** (real-world Jira behavior) and rendered via two new `MarkdownConfig` options:

| Option | Default | Description |
|--------|---------|-------------|
| `date_timezone` | `UTC` | IANA timezone name (e.g. `America/New_York`), DST-aware via `chrono-tz` |
| `date_format` | `%Y-%m-%dT%H:%M:%S%:z` | chrono strftime pattern; default is ISO 8601 date **and** time |

```python
from pyadf import Document, MarkdownConfig

adf = {"type": "date", "attrs": {"timestamp": "1582152559000"}}

Document(adf).to_markdown()
# '2020-02-19T22:49:19+00:00'

Document(adf).to_markdown(MarkdownConfig(date_timezone="America/New_York", date_format="%Y-%m-%d %H:%M %Z"))
# '2020-02-19 17:49 EST'
```

## Behaviour notes

- **Timestamp is a string per the ADF spec.** A missing, non-string, or non-integer-parseable value raises `MissingFieldError` / `InvalidFieldError` at `Document(...)` construction time.
- **Config validation** (timezone name, strftime pattern) happens when the config crosses into Rust, raising `ValueError` on invalid input.
- **Round-trips** back to a dict with the timestamp serialized as a string.

## Tests

Rust unit tests (parsing, rendering, timezone/format, config validation) and Python tests (`tests/test_conversion.py::TestDate`, `tests/test_config.py::TestDateConfig`). README and `docs/adf-element-policy.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)